### PR TITLE
Update dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
 
 Metrics/LineLength:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,33 @@ GEM
   remote: https://rubygems.org/
   specs:
     asciidoctor (2.0.15)
-    ast (2.4.0)
-    concurrent-ruby (1.0.5)
-    docile (1.3.1)
-    equatable (0.5.0)
-    jaro_winkler (1.5.1)
-    minitest (5.11.3)
-    parallel (1.12.1)
-    parser (2.5.1.2)
-      ast (~> 2.4.0)
-    pastel (0.7.2)
-      equatable (~> 0.5.0)
-      tty-color (~> 0.4.0)
-    powerpack (0.1.2)
+    ast (2.4.2)
+    concurrent-ruby (1.1.8)
+    docile (1.3.5)
+    minitest (5.14.4)
+    parallel (1.20.1)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
     rainbow (3.0.0)
-    rake (12.3.3)
-    rubocop (0.58.2)
-      jaro_winkler (~> 1.5.1)
+    rake (13.0.3)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.13.0)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.10.0)
-    tty-color (0.4.3)
-    unicode-display_width (1.4.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    tty-color (0.6.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -40,3 +41,6 @@ DEPENDENCIES
   pastel
   rake
   rubocop
+
+BUNDLED WITH
+   2.2.5

--- a/lib/jobrnr/job/pool.rb
+++ b/lib/jobrnr/job/pool.rb
@@ -45,7 +45,7 @@ module Jobrnr
       end
 
       def create_futures(instances)
-        instances.map { |instance| Concurrent::Future.execute { instance.execute } }
+        instances.map { |instance| Concurrent::Promises.future { instance.execute } }
       end
     end
   end

--- a/test/cli_job_exit_status_test.rb
+++ b/test/cli_job_exit_status_test.rb
@@ -6,8 +6,8 @@ describe "CLI Job Exit Status" do
       yield
     end
 
-    out.must_match exp_out
-    err.must_match exp_err
+    expect(out).must_match exp_out
+    expect(err).must_match exp_err
   end
 
   it "fails" do
@@ -29,8 +29,8 @@ describe "CLI Job Exit Status" do
       system "bin/jobrnr test/fixtures/job_exit_status/pass_and_fail.rb"
     end
 
-    out.must_match(/PASSED: 'true'/)
-    out.must_match(/FAILED: 'false'/)
-    err.must_equal ""
+    expect(out).must_match(/PASSED: 'true'/)
+    expect(out).must_match(/FAILED: 'false'/)
+    expect(err).must_equal ""
   end
 end


### PR DESCRIPTION
Using rake 13.0.3 (was 12.3.3)
Using asciidoctor 2.0.15
Using ast 2.4.2 (was 2.4.0)
Using bundler 2.2.5
Using parser 3.0.1.1 (was 2.5.1.2)
Using docile 1.3.5 (was 1.3.1)
Using rubocop-ast 1.5.0
Using parallel 1.20.1 (was 1.12.1)
Using tty-color 0.6.0 (was 0.4.3)
Using rainbow 3.0.0
Using regexp_parser 2.1.1
Using rexml 3.2.5
Using ruby-progressbar 1.11.0 (was 1.10.0)
Using unicode-display_width 2.0.0 (was 1.4.0)
Using concurrent-ruby 1.1.8 (was 1.0.5)
Using rubocop 1.13.0 (was 0.58.2)
Using pastel 0.8.0 (was 0.7.2)
Using minitest 5.14.4 (was 5.11.3)