### PR TITLE
Speed up CLI tests

### DIFF
--- a/lib/jobrnr/application.rb
+++ b/lib/jobrnr/application.rb
@@ -41,12 +41,20 @@ module Jobrnr
       # load plugins
       Jobrnr::Plugins.instance.load(options.plugin_paths)
 
-      Jobrnr::DSL::Loader.instance.evaluate(nil, filename, options, plus_options)
+      graph = Jobrnr::Graph.new
+
+      Jobrnr::DSL::Loader.instance.evaluate(
+        prefix: nil,
+        filename: filename,
+        graph: graph,
+        options: options,
+        plus_options: plus_options,
+      )
       option_parser.parse(post_args)
       option_parser.expand_output_directory
 
       if options.dot
-        Jobrnr::Log.info Jobrnr::Graph.instance.to_dot
+        Jobrnr::Log.info graph.to_dot
         exit
       end
 
@@ -59,7 +67,7 @@ module Jobrnr
       )
       Jobrnr::Job::Dispatch.new(
         options: options,
-        graph: Jobrnr::Graph.instance,
+        graph: graph,
         pool: pool,
         stats: Jobrnr::Stats.new,
         slots: slots,

--- a/lib/jobrnr/dsl/loader.rb
+++ b/lib/jobrnr/dsl/loader.rb
@@ -16,12 +16,19 @@ module Jobrnr
         @script_obj = nil
       end
 
-      def evaluate(prefix, filename, *init_args)
+      def evaluate(prefix:, filename:, graph:, options:, plus_options:)
         @imports.push(@import) if @import
         @prefixes.push(prefix) if prefix
         @import = { filename: filename, prefix: prefix }
         @script_objs.push(@script_obj) if @script_obj
-        @script_obj = Jobrnr::Script.load(filename, { init_args: init_args, base_class: Jobrnr::DSL::Commands })
+        @script_obj =
+          Jobrnr::Script.load(
+            filename: filename,
+            graph: graph,
+            baseclass: Jobrnr::DSL::Commands,
+            options: options,
+            plus_options: plus_options,
+          )
         @script_obj = @script_objs.pop if @script_objs.size.positive?
         @import = @imports.pop if @imports.size.positive?
         @prefixes.pop

--- a/lib/jobrnr/graph.rb
+++ b/lib/jobrnr/graph.rb
@@ -5,8 +5,6 @@ module Jobrnr
 
   # Tracks job dependencies
   class Graph
-    include Singleton
-
     def initialize
       @jobs = {}
     end

--- a/lib/jobrnr/script.rb
+++ b/lib/jobrnr/script.rb
@@ -5,14 +5,17 @@ module Jobrnr
   # loaded without namespace conflicts
   class Script
     # param code [String] ruby code to evaluate
-    # param opts [Hash]
-    def self.eval(code, opts = {})
-      filename = opts[:filename]
-      base_class = opts[:base_class]
-      init_args = opts[:init_args] || []
-
-      class_obj = Class.new(base_class)
-      obj = class_obj.new(*init_args)
+    # param graph [Jobrnr::Graph] the job graph object
+    # param baseclass [Class] the class context to eval within
+    # param options [Struct] the options struct
+    # param plus_options [Struct] the plus options struct
+    def self.eval(code:, filename:, graph:, baseclass:, options:, plus_options:)
+      class_obj = Class.new(baseclass)
+      obj = class_obj.new(
+        graph: graph,
+        options: options,
+        plus_options: plus_options,
+      )
 
       begin
         obj.instance_eval(code, filename)
@@ -24,12 +27,20 @@ module Jobrnr
     end
 
     # param filename [String] filename to load
-    # param opts [Hash]
-    def self.load(filename, opts = {})
-      opts[:filename] = filename
-
+    # param graph [Jobrnr::Graph] the job graph object
+    # param baseclass [Class] the class context to eval within
+    # param options [Struct] the options struct
+    # param plus_options [Struct] the plus options struct
+    def self.load(filename:, graph:, baseclass:, options:, plus_options:)
       code = IO.read(filename)
-      self.eval(code, opts)
+      self.eval(
+        code: code,
+        filename: filename,
+        graph: graph,
+        baseclass: baseclass,
+        options: options,
+        plus_options: plus_options,
+      )
     end
   end
 end

--- a/lib/jobrnr/ui.rb
+++ b/lib/jobrnr/ui.rb
@@ -9,12 +9,13 @@ module Jobrnr
     attr_reader :ctrl_c
     attr_reader :pool
 
-    TIME_SLICE_INTERVAL = 1
+    DEFAULT_TIME_SLICE_INTERVAL = 1
 
     def initialize(pool:)
       @color = Pastel.new
       @ctrl_c = 0
       @pool = pool
+      @time_slice_interval = Float(ENV.fetch("JOBRNR_TIME_SLICE_INTERVAL", DEFAULT_TIME_SLICE_INTERVAL))
 
       trap_ctrl_c
     end
@@ -52,7 +53,7 @@ module Jobrnr
     end
 
     def sleep
-      Kernel.sleep TIME_SLICE_INTERVAL
+      Kernel.sleep @time_slice_interval
     end
 
     def stop_submission?

--- a/test/cli_job_exit_status_test.rb
+++ b/test/cli_job_exit_status_test.rb
@@ -3,9 +3,19 @@
 require "test_helper"
 
 describe "CLI Job Exit Status" do
-  def assert_subprocess_io_matches(exp_out, exp_err)
-    out, err = capture_subprocess_io do
-      yield
+  def no_color(&block)
+    ENV["NO_COLOR"] = "1"
+    block.call
+    ENV.delete("NO_COLOR")
+  end
+
+  def assert_io_matches(exp_out, exp_err)
+    out, err = capture_io do
+      no_color do
+        Kernel.stub(:trap, nil) do
+          yield
+        end
+      end
     end
 
     expect(out).must_match exp_out
@@ -14,21 +24,21 @@ describe "CLI Job Exit Status" do
 
   it "fails" do
     exp_out = /FAILED: 'false'/
-    assert_subprocess_io_matches(exp_out, "") do
-      system "bin/jobrnr test/fixtures/job_exit_status/fail.rb"
+    assert_io_matches(exp_out, "") do
+      Jobrnr::Application.new(%w[test/fixtures/job_exit_status/fail.rb -d fail]).run
     end
   end
 
   it "passes" do
     exp_out = /PASSED: 'true'/
-    assert_subprocess_io_matches(exp_out, "") do
-      system "bin/jobrnr test/fixtures/job_exit_status/pass.rb"
+    assert_io_matches(exp_out, "") do
+      Jobrnr::Application.new(%w[test/fixtures/job_exit_status/pass.rb -d pass]).run
     end
   end
 
   it "passes and fails" do
     out, err = capture_subprocess_io do
-      system "bin/jobrnr test/fixtures/job_exit_status/pass_and_fail.rb"
+      Jobrnr::Application.new(%w[test/fixtures/job_exit_status/pass_and_fail.rb -d pass_and_fail]).run
     end
 
     expect(out).must_match(/PASSED: 'true'/)

--- a/test/cli_job_exit_status_test.rb
+++ b/test/cli_job_exit_status_test.rb
@@ -12,8 +12,10 @@ describe "CLI Job Exit Status" do
   def assert_io_matches(exp_out, exp_err)
     out, err = capture_io do
       no_color do
-        Kernel.stub(:trap, nil) do
-          yield
+        speedup do
+          Kernel.stub(:trap, nil) do
+            yield
+          end
         end
       end
     end

--- a/test/cli_option_precedence_test.rb
+++ b/test/cli_option_precedence_test.rb
@@ -12,7 +12,7 @@ describe "CLI option precedence" do
     it "set the option" do
       argv = %w[--output-directory a test/fixtures/cli_option_precendence_test/none.rb]
       app = Jobrnr::Application.new(argv)
-      app.run
+      speedup { app.run }
       expect(app.option_parser.options.output_directory).must_equal File.expand_path("a")
     end
   end
@@ -21,7 +21,7 @@ describe "CLI option precedence" do
     it "overrides command-line options before it" do
       argv = %w[--output-directory a test/fixtures/cli_option_precendence_test/some.rb]
       app = Jobrnr::Application.new(argv)
-      app.run
+      speedup { app.run }
       expect(app.option_parser.options.output_directory).must_equal File.expand_path("b")
     end
   end
@@ -30,7 +30,7 @@ describe "CLI option precedence" do
     it "overrides script options" do
       argv = %w[--output-directory a test/fixtures/cli_option_precendence_test/some.rb -d c]
       app = Jobrnr::Application.new(argv)
-      app.run
+      speedup { app.run }
       expect(app.option_parser.options.output_directory).must_equal File.expand_path("c")
     end
   end

--- a/test/cli_plus_options_test.rb
+++ b/test/cli_plus_options_test.rb
@@ -5,8 +5,10 @@ require "test_helper"
 describe "CLI Plus Options" do
   def assert_io_matches(exp_out, exp_err)
     out, err = capture_io do
-      Kernel.stub(:trap, nil) do
-        yield
+      speedup do
+        Kernel.stub(:trap, nil) do
+          yield
+        end
       end
     end
 

--- a/test/cli_plus_options_test.rb
+++ b/test/cli_plus_options_test.rb
@@ -3,9 +3,11 @@
 require "test_helper"
 
 describe "CLI Plus Options" do
-  def assert_subprocess_io_matches(exp_out, exp_err)
-    out, err = capture_subprocess_io do
-      yield
+  def assert_io_matches(exp_out, exp_err)
+    out, err = capture_io do
+      Kernel.stub(:trap, nil) do
+        yield
+      end
     end
 
     assert_equal exp_out, out
@@ -19,8 +21,8 @@ describe "CLI Plus Options" do
         child: {:name=>"child-name", :present=>false}
       EOF
 
-      assert_subprocess_io_matches(exp_out, "") do
-        system "bin/jobrnr examples/plus_options_import/index.jr"
+      assert_io_matches(exp_out, "") do
+        Jobrnr::Application.new(%w[examples/plus_options_import/index.jr]).run
       end
     end
 
@@ -30,8 +32,8 @@ describe "CLI Plus Options" do
         child: {:name=>"bar", :present=>true}
       EOF
 
-      assert_subprocess_io_matches(exp_out, "") do
-        system "bin/jobrnr examples/plus_options_import/index.jr +name=foo +child-name=bar +present"
+      assert_io_matches(exp_out, "") do
+        Jobrnr::Application.new(%w[examples/plus_options_import/index.jr +name=foo +child-name=bar +present]).run
       end
     end
   end

--- a/test/dsl_command_error_test.rb
+++ b/test/dsl_command_error_test.rb
@@ -12,8 +12,12 @@ end
 
 describe "DSL command usage errors" do
   before do
-    Jobrnr::Graph.instance.clear
-    @obj = Jobrnr::DSL::Commands.new({}, {})
+    graph = Jobrnr::Graph.new
+    @obj = Jobrnr::DSL::Commands.new(
+      graph: graph,
+      options: {},
+      plus_options: {},
+    )
   end
 
   describe "job command" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,9 @@
 require "minitest/autorun"
 
 require "jobrnr"
+
+def speedup(&block)
+  ENV["JOBRNR_TIME_SLICE_INTERVAL"] = "0"
+  block.call
+  ENV.delete("JOBRNR_TIME_SLICE_INTERVAL")
+end


### PR DESCRIPTION
This PR speeds up CLI tests by:

1. Refactoring integration tests to run in-process instead of a sub-process
2. Reducing sleep duration from 1 second to 0 seconds

This reduces the total test time from 7.214 seconds to 2.431 seconds.

This required a medium refactor to remove `Singleton` from `Jobrnr::Graph`.