### PR TITLE
Send SIGTERM on third Ctrl-C

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,7 +34,8 @@ Previous behavior can be kept by making the following change:
 * Added graceful Ctrl-C handling
 +
 First Ctrl-C stops submission of new jobs and allows active jobs to complete.
-Second Ctrl-C sends Ctrl-C to active jobs.
+Second Ctrl-C sends Ctrl-C (i.e. SIGINT) to active jobs.
+Third Ctrl-C sends SIGTERM to active jobs.
 
 * Added internal support for dynamic job scaling.
 +

--- a/lib/jobrnr/job/instance.rb
+++ b/lib/jobrnr/job/instance.rb
@@ -52,6 +52,12 @@ module Jobrnr
         Process.kill("INT", pid)
       end
 
+      def sigterm
+        return unless state == :dispatched && pid.positive?
+
+        Process.kill("TERM", pid)
+      end
+
       def duration
         @end_time - @start_time
       end

--- a/lib/jobrnr/job/pool.rb
+++ b/lib/jobrnr/job/pool.rb
@@ -47,6 +47,10 @@ module Jobrnr
         instances.each(&:sigint)
       end
 
+      def sigterm
+        instances.each(&:sigterm)
+      end
+
       private
 
       attr_accessor :futures

--- a/lib/jobrnr/ui.rb
+++ b/lib/jobrnr/ui.rb
@@ -89,16 +89,20 @@ module Jobrnr
     # Handle Ctrl-C
     #
     # On first Ctrl-C, stop submitting new jobs and allow current jobs to
-    # finish. On second Ctrl-C (and beyond), send Ctrl-C to jobs.
+    # finish. On second Ctrl-C, send SIGINT to jobs. On third (and subsequent)
+    # Ctrl-C, send SIGTERM to jobs.
     def process_ctrl_c
       case ctrl_c
       when 0
         Jobrnr::Log.info "Stopping job submission. Allowing active jobs to finish."
-        Jobrnr::Log.info "Ctrl-C again to terminate active jobs gracefully."
-      else
-        Jobrnr::Log.info "Terminating by sending Ctrl-C (SIGINT) to jobs."
-        Jobrnr::Log.info "Ctrl-C again to send Ctrl-C (SIGINT) again."
+        Jobrnr::Log.info "Ctrl-C again to interrupt (SIGINT) active jobs."
+      when 1
+        Jobrnr::Log.info "Interrupting (SIGINT) jobs."
+        Jobrnr::Log.info "Ctrl-C again to terminate (SIGTERM) active jobs."
         pool.sigint
+      else
+        Jobrnr::Log.info "Terminating (SIGTERM) jobs."
+        pool.sigterm
       end
 
       @ctrl_c += 1


### PR DESCRIPTION
This PR adds a third state to Ctrl-C handling.  The states are now:

1. Stop job submission
2. Send SIGINT to active jobs
3. Send SIGTERM to active jobs