### PR TITLE
Simplify log paths

### DIFF
--- a/lib/jobrnr/job/dispatch.rb
+++ b/lib/jobrnr/job/dispatch.rb
@@ -151,7 +151,7 @@ module Jobrnr
       def log_filename(slot)
         File.join(
           options.output_directory,
-          format("%<dirname>s%<slot_id>02d", dirname: File.basename(options.output_directory), slot_id: slot)
+          slot.to_s
         )
       end
     end

--- a/lib/jobrnr/ui.rb
+++ b/lib/jobrnr/ui.rb
@@ -244,11 +244,7 @@ module Jobrnr
     end
 
     def format_command(inst)
-      format(
-        "'%<command>s' %<log>s",
-        command: inst.to_s,
-        log: File.basename(inst.log),
-      )
+      format("'%s'", inst.to_s)
     end
 
     def format_slot(inst)

--- a/test/cli_job_exit_status_test.rb
+++ b/test/cli_job_exit_status_test.rb
@@ -43,13 +43,13 @@ describe "CLI Job Exit Status" do
       Jobrnr::Application.new(%w[test/fixtures/job_exit_status/pass_and_fail.rb -j1 -d pass_and_fail]).run
     end
 
-    expect(out).must_match(/PASSED: 'job 0' pass_and_fail00 slot:recycled exitcode:0/)
-    expect(out).must_match(/FAILED: 'job 1' pass_and_fail00 slot:0 exitcode:1/)
-    expect(out).must_match(/FAILED: 'job 42' pass_and_fail01 slot:1 exitcode:42/)
-    expect(out).must_match(/FAILED: 'command_not_found arg' pass_and_fail02 slot:2 exitcode:n\/a/)
+    expect(out).must_match(/PASSED: 'job 0' slot:recycled exitcode:0/)
+    expect(out).must_match(/FAILED: 'job 1' slot:0 exitcode:1/)
+    expect(out).must_match(/FAILED: 'job 42' slot:1 exitcode:42/)
+    expect(out).must_match(/FAILED: 'command_not_found arg' slot:2 exitcode:n\/a/)
     expect(err).must_equal ""
 
-    command_not_found_output = File.read("pass_and_fail/pass_and_fail02")
+    command_not_found_output = File.read("pass_and_fail/2")
     expect(command_not_found_output).must_equal("ERROR: failed to spawn command 'command_not_found arg' for job 'command_not_found': No such file or directory - command_not_found")
   end
 end


### PR DESCRIPTION
BREAKING CHANGE: changes log paths from dirname/dirnameXX to dirname/X. For example, if the output directory were /my/path and the slot was 7, the log path changed from /my/path/path7 to /my/path/7.